### PR TITLE
Update ySelect.js

### DIFF
--- a/js/ySelect.js
+++ b/js/ySelect.js
@@ -186,7 +186,7 @@
             var selected = $(this).attr('data-value');
             $wrap.find('.fs-option').removeClass('selected');
             $(this).addClass('selected');
-            $wrap.find('.fs-dropdown').hide();
+            $wrap.find('.fs-dropdown').addClass('hidden');
         }
 
         $wrap.find('select').val(selected);


### PR DESCRIPTION
修复在谷歌浏览器下，单选只能选一次的问题。该问题主要是由于jquery的hide是直接加style属性，导致后期再次点击下拉框的时候，该属性并没有被移除，导致下拉框没有显示